### PR TITLE
Fix url provider

### DIFF
--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -80,7 +80,7 @@ class MinecraftEduURLProvider(Processor):
             release = item[:-build_length].split("_")
             # Convert version number to a distutils.version.LooseVersion, and
             # the build to an int.
-            version_numbers.append((LooseVersion(release[0]), release[1]))
+            version_numbers.append((LooseVersion(release[0]), int(release[1])))
         version_numbers.sort(reverse=True)
         # version_numbers[0][0] = latest version
         # version_numbers[0][1] = latest build


### PR DESCRIPTION
Hello Mr. McSpadden,
I was updating my slightly modified version of your MinecraftEdu recipe and discovered that it was not able to grab the devel builds. Looking more closely at the MinecraftEduURLProvider.py, I noticed that since it was converting the version number to a float, the recently released 1.710 was getting converted to 1.71, and thus the returned URL was incorrect and failed.

This is kind of a quick and dirty way to solve it. Feel free to ignore and do it the way you like it ;).
