### PR TITLE
Update GoogleEarthPro recipe for new package format.

### DIFF
--- a/GoogleEarthPro/GoogleEarthPro.pkg.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.pkg.recipe
@@ -17,40 +17,69 @@
 	<string>com.github.autopkg.nmcspadden-recipes.download.google-earth-pro</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
-			<key>Arguments</key>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
+				<key>flat_pkg_path</key>
+                <string>%pathname%/Install Google Earth.pkg</string>
+				<key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked_package</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-			<key>Arguments</key>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
 			<dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-					<key>Library</key>
-					<string>0755</string>
-					<key>Library/Profiles</key>
-					<string>0755</string>
-				</dict>
+				<key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked_package/Google_Earth_Pro.pkg/Payload</string>
+				<key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked_app/</string>
 			</dict>
-		</dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked_app/Google Earth Pro.app/Contents/Info.plist</string>
+				<key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>CFBundleIdentifier</key>
+                    <string>bundleid</string>
+                </dict>
+			</dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0775</string>
+                    <key>Library</key>
+                    <string>0755</string>
+                    <key>Library/Profiles</key>
+                    <string>0755</string>
+                </dict>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>Copier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/Google Earth Pro.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked_app/Google Earth Pro.app</string>
 				<key>destination_path</key>
 				<string>%pkgroot%/Applications/Google Earth Pro.app</string>
 			</dict>


### PR DESCRIPTION
This should do it.

It occurred to me that people might be wary of including the profile that you provided; could that become an option to opt out of?

