### PR TITLE
Cleanup pkgroot

### DIFF
--- a/AppStoreApp/AppStoreApp.pkg.recipe
+++ b/AppStoreApp/AppStoreApp.pkg.recipe
@@ -119,6 +119,18 @@
                 </dict>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%pkgroot%</string>
+                    <string>%infofile%</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Cleanup pkgroot so apps can't be mistakenly registered in the wrong directory.