### PR TITLE
Update code signature verifier authority name

### DIFF
--- a/GoogleEarthPro/GoogleEarthPro.download.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.download.recipe
@@ -41,7 +41,7 @@
 				<string>%pathname%/*.pkg</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Google Inc.</string>
+                    <string>Developer ID Installer: Google, Inc. (EQHXZ8M8AV)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
Current recipe produces:
CodeSignatureVerifier: Expected: Developer ID Installer: Google Inc. -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: Google, Inc. (EQHXZ8M8AV) -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.

Updated code signature verifier authority name to match changed string.