### PR TITLE
Add wildcard to the installer pkg name

### DIFF
--- a/GoogleEarthPro/GoogleEarthPro.munki.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.munki.recipe
@@ -60,7 +60,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/expanded</string>
                 <key>flat_pkg_path</key>
-                <string>%pathname%/Install Google Earth.pkg</string>
+                <string>%pathname%/Install Google Earth*.pkg</string>
             </dict>
         </dict>
         <dict>

--- a/GoogleEarthPro/GoogleEarthPro.pkg.recipe
+++ b/GoogleEarthPro/GoogleEarthPro.pkg.recipe
@@ -41,7 +41,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/expanded</string>
                 <key>flat_pkg_path</key>
-                <string>%pathname%/Install Google Earth.pkg</string>
+                <string>%pathname%/Install Google Earth*.pkg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The installer now has the version number in the name: "Install Google Earth Pro 7.1.8.3036_m.pkg"