### PR TITLE
fix: Correct chefdk download id

### DIFF
--- a/ChefDK/ChefDK.download.recipe
+++ b/ChefDK/ChefDK.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest Chef DK for Mac version.</string>
     <key>Identifier</key>
-    <string>com.facebook.autopkg.download.chefdk</string>
+    <string>com.github.autopkg.download.chefdk</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
Since other recipes are using this download recipe the identifier should
stay the same. Revert 6cffe05a0738c83272edeb8a11125e39804e6a52
identifier change.

This also fixes ChefDK.munki