### PR TITLE
Basic python3 compatibility

### DIFF
--- a/AppStoreApp/AppStoreUpdateChecker.py
+++ b/AppStoreApp/AppStoreUpdateChecker.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 import urllib2
 import plistlib
-import sys
 
 from autopkglib import Processor, ProcessorError
 from Foundation import NSData, NSPropertyListSerialization, NSPropertyListMutableContainers
@@ -135,14 +134,14 @@ def unwind(input):
 
 def extract_data(asn1_seq):
     ret_val = []
-    for i,x in enumerate(asn1_seq):
-        if (type(x) is tuple):
+    for i, x in enumerate(asn1_seq):
+        if isinstance(x, tuple):
             if len(x) == 3:
                 if x[2] == '1.2.840.113549.1.7.1':
                     ret_val.append(asn1_seq[i+2][0][2])
-        elif (type(x) is list):
+        elif isinstance(x, list):
             sub_val = extract_data(x)
-            if (type(sub_val) is list):
+            if isinstance(sub_val, list):
                 ret_val.extend(sub_val)
             else:
                 ret_val.append(sub_val)
@@ -152,7 +151,7 @@ def extract_data(asn1_seq):
 
 def parse_receipt(rec):
     ret_val = []
-    for y in [z for z in rec if type(z) is list]:
+    for y in [z for z in rec if isinstance(z, list)]:
         try:
             dec = asn1.Decoder()
             dec.start(y[2][2])
@@ -272,7 +271,7 @@ class AppStoreUpdateChecker(Processor):
 
         plistpath = os.path.join(path, "Contents", "Info.plist")
         if not (os.path.isfile(plistpath)):
-			raise ProcessorError("File does not exist: %s" % plistpath)
+            raise ProcessorError("File does not exist: %s" % plistpath)
         info, format, error = \
             NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
                 NSData.dataWithContentsOfFile_(plistpath),
@@ -307,7 +306,7 @@ class AppStoreUpdateChecker(Processor):
                 decoded_receipt = get_app_receipt(app_item)
             except IOError as e:
                 raise ProcessorError("Invalid path %s: %s" % (app_item, e))
-            details = { t.type: t.value for t in decoded_receipt }
+            details = {t.type: t.value for t in decoded_receipt}
             app_dict['CFBundleIdentifier'] = details['Bundle Identifier']
             app_dict['installed-version-identifier'] = int(details['App Store Installer Version ID'])
             app_dict['adam-id'] = details['Product ID']
@@ -340,4 +339,3 @@ class AppStoreUpdateChecker(Processor):
 if __name__ == '__main__':
     processor = AppStoreUpdateChecker()
     processor.execute_shell()
-

--- a/AppStoreApp/AppStoreUpdateChecker.py
+++ b/AppStoreApp/AppStoreUpdateChecker.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import plistlib
 import sys
@@ -223,7 +224,7 @@ def check_app_updates(app_info_list, raw_result=False):
     response_handle = urllib2.urlopen(request)
     try:
         response = response_handle.read()
-    except HTTPError, e:
+    except HTTPError as e:
         raise ProcessorError("Invalid adam-id %s" % e)
     response_handle.close()
     # Currently returning the raw response
@@ -304,7 +305,7 @@ class AppStoreUpdateChecker(Processor):
                 return
             try:
                 decoded_receipt = get_app_receipt(app_item)
-            except IOError, e:
+            except IOError as e:
                 raise ProcessorError("Invalid path %s: %s" % (app_item, e))
             details = { t.type: t.value for t in decoded_receipt }
             app_dict['CFBundleIdentifier'] = details['Bundle Identifier']
@@ -317,7 +318,7 @@ class AppStoreUpdateChecker(Processor):
         app_details.append(app_dict)
         try:
             item_details = check_app_updates(app_details)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             raise ProcessorError("Invalid adam-id %s: %s" % (app_item, e))
         # If item_details contains a key 'incompatible-items', it means the version we have is not up to date.
         # So now we can check for the presence of 'incompatible-items' and then report that there's an update available with a specific version

--- a/AppStoreApp/AppStoreUpdateChecker.py
+++ b/AppStoreApp/AppStoreUpdateChecker.py
@@ -15,11 +15,18 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
+
+import os
 import plistlib
+import urllib2
+from collections import namedtuple
 
 from autopkglib import Processor, ProcessorError
-from Foundation import NSData, NSPropertyListSerialization, NSPropertyListMutableContainers
+from Foundation import (
+    NSData,
+    NSPropertyListMutableContainers,
+    NSPropertyListSerialization,
+)
 
 # pyMASreceipt - python module for parsing the contents of _MASReceipt/receipt file inside a Mac App Store .app
 #
@@ -64,8 +71,6 @@ try:
 except ImportError:
     pymasreceipt_avail = False
     #raise ProcessorError("asn1 not found.  Please install asn1 from https://github.com/geertj/python-asn1")
-import os
-from collections import namedtuple
 MASattr = namedtuple('MASattr', 'type version value')
 
 # The following attributes were determined from looking at the JSON attributes for a MAS app and the output

--- a/AppStoreApp/PkgBuildTester.py
+++ b/AppStoreApp/PkgBuildTester.py
@@ -16,6 +16,7 @@
 """Look in the build directory for a pre-existing package."""
 
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import xml.etree.ElementTree as ET

--- a/AppStoreApp/PkgBuildTester.py
+++ b/AppStoreApp/PkgBuildTester.py
@@ -17,12 +17,12 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PkgBuildTester"]
 
@@ -128,4 +128,3 @@ class PkgBuildTester(Processor):
 if __name__ == '__main__':
     PROCESSOR = PkgBuildTester()
     PROCESSOR.execute_shell()
-

--- a/CreateUserPkgMunki/PackageInfoReader.py
+++ b/CreateUserPkgMunki/PackageInfoReader.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PackageInfoReader class"""
 
+from __future__ import absolute_import
 import os.path
 import xml.etree.ElementTree as ET
 

--- a/CreateUserPkgMunki/PackageInfoReader.py
+++ b/CreateUserPkgMunki/PackageInfoReader.py
@@ -16,11 +16,11 @@
 """See docstring for PackageInfoReader class"""
 
 from __future__ import absolute_import
+
 import os.path
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PackageInfoReader"]
 

--- a/CreateUserPkgMunki/PackageInfoReader.py
+++ b/CreateUserPkgMunki/PackageInfoReader.py
@@ -49,7 +49,7 @@ class PackageInfoReader(Processor):
 
 
     def main(self):
-    	path = self.env["info_path"]
+        path = self.env["info_path"]
         # Check whether this is at least a valid path
         if not os.path.exists(path):
             raise ProcessorError("Path '%s' doesn't exist!" % path)
@@ -72,7 +72,7 @@ class PackageInfoReader(Processor):
             # This one is for documentation/recordkeeping
             self.env["packageinfo_reader_output_variables"]["packageinfo_" + str(key)] = (
                 self.env["packageinfo_" + str(key)])
-     
+
 
 
 if __name__ == '__main__':

--- a/CreateUserPkgMunki/UserPlistReader.py
+++ b/CreateUserPkgMunki/UserPlistReader.py
@@ -17,11 +17,11 @@
 """See docstring for UserPlistReader class"""
 
 from __future__ import absolute_import
+
 import os.path
+
 import FoundationPlist
-
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["UserPlistReader"]
 

--- a/CreateUserPkgMunki/UserPlistReader.py
+++ b/CreateUserPkgMunki/UserPlistReader.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """See docstring for UserPlistReader class"""
 
+from __future__ import absolute_import
 import os.path
 import FoundationPlist
 

--- a/Minecraft/LZMADecompress.py
+++ b/Minecraft/LZMADecompress.py
@@ -24,44 +24,42 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["LZMADecompress"]
 
 class LZMADecompress(Processor):
-	description = "Decompresses an LZMA file using xz, a precompiled binary for OS X 10.5+."
-	input_variables = {
-		"lzma_file": {
-			"required": True,
-			"description": ("Path to .lzma file."),
-		},
-		"decompressor": {
-			"required": True,
-			"description": ("Path to xz binary."),
-		}
-	}
-	output_variables = {
-	}
+    description = "Decompresses an LZMA file using xz, a precompiled binary for OS X 10.5+."
+    input_variables = {
+        "lzma_file": {
+            "required": True,
+            "description": ("Path to .lzma file."),
+        },
+        "decompressor": {
+            "required": True,
+            "description": ("Path to xz binary."),
+        }
+    }
+    output_variables = {
+    }
 
-	__doc__ = description
+    __doc__ = description
 
-	def decompress_the_file(self):
-		file = self.env.get("lzma_file")
-		if not file:
-			raise ProcessorError("lzma_file not found: %s" % (file))
-		xz = self.env.get("decompressor")
-		if not xz:
-			raise ProcessorError("xz binary not found: %s" % (xz))
-		cmd = [xz,'-k','--format=lzma','--decompress',file]
-		proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		(output, errors) = proc.communicate()
-		return errors      
+    def decompress_the_file(self):
+        file = self.env.get("lzma_file")
+        if not file:
+            raise ProcessorError("lzma_file not found: %s" % (file))
+        xz = self.env.get("decompressor")
+        if not xz:
+            raise ProcessorError("xz binary not found: %s" % (xz))
+        cmd = [xz,'-k','--format=lzma','--decompress',file]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (output, errors) = proc.communicate()
+        return errors
 
-	def main(self):
-		'''Does nothing except decompresses the file'''
-		if "lzma_file" in self.env:
-			self.output("Using input LZMA file %s decompressing with %s" % (self.env["lzma_file"], self.env["decompressor"]))
-		self.env["results"] = self.decompress_the_file()
-		self.output("Decompressed: %s" % self.env["results"])
+    def main(self):
+        '''Does nothing except decompresses the file'''
+        if "lzma_file" in self.env:
+            self.output("Using input LZMA file %s decompressing with %s" % (self.env["lzma_file"], self.env["decompressor"]))
+        self.env["results"] = self.decompress_the_file()
+        self.output("Decompressed: %s" % self.env["results"])
 
 
 if __name__ == '__main__':
     processor = LZMADecompress()
     processor.execute_shell()
-    
-

--- a/Minecraft/LZMADecompress.py
+++ b/Minecraft/LZMADecompress.py
@@ -17,6 +17,7 @@
 #I would just like to state, for the record, I am fully aware of how awful this script is.
 #I will eventually fix it to make it much more robust, but it's more of a "get-it-done" kind of solution.
 
+from __future__ import absolute_import
 import subprocess
 from autopkglib import Processor, ProcessorError
 

--- a/Minecraft/LZMADecompress.py
+++ b/Minecraft/LZMADecompress.py
@@ -18,7 +18,9 @@
 #I will eventually fix it to make it much more robust, but it's more of a "get-it-done" kind of solution.
 
 from __future__ import absolute_import
+
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["LZMADecompress"]

--- a/Minecraft/Unpack200.py
+++ b/Minecraft/Unpack200.py
@@ -17,6 +17,7 @@
 # I would just like to state, for the record, I am fully aware of how awful this script is.
 # I will eventually fix it to make it much more robust, but it's more of a "get-it-done" kind of solution.
 
+from __future__ import absolute_import
 import subprocess
 from autopkglib import Processor, ProcessorError
 

--- a/Minecraft/Unpack200.py
+++ b/Minecraft/Unpack200.py
@@ -24,44 +24,42 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["Unpack200"]
 
 class Unpack200(Processor):
-	description = "Unpacks a Java .pack file."
-	input_variables = {
-		"file_path": {
-			"required": True,
-			"description": ("Path to .pack file."),
-		},
-		"destination": {
-			"required": True,
-			"description": ("Location to unpack the file."),
-		}
-	}
-	output_variables = {
-	}
+    description = "Unpacks a Java .pack file."
+    input_variables = {
+        "file_path": {
+            "required": True,
+            "description": ("Path to .pack file."),
+        },
+        "destination": {
+            "required": True,
+            "description": ("Location to unpack the file."),
+        }
+    }
+    output_variables = {
+    }
 
-	__doc__ = description
+    __doc__ = description
 
-	def unpack_the_file(self):
-		file = self.env.get("file_path")
-		if not file:
-			raise ProcessorError("file_path not found: %s" % (file))
-		destination = self.env.get("destination")
-		if not destination:
-			raise ProcessorError("destination not found: %s" % (destination))
-		cmd = ['/usr/bin/unpack200',file,destination]
-		proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		(output, errors) = proc.communicate()
-		return output      
+    def unpack_the_file(self):
+        file = self.env.get("file_path")
+        if not file:
+            raise ProcessorError("file_path not found: %s" % (file))
+        destination = self.env.get("destination")
+        if not destination:
+            raise ProcessorError("destination not found: %s" % (destination))
+        cmd = ['/usr/bin/unpack200',file,destination]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (output, errors) = proc.communicate()
+        return output
 
-	def main(self):
-		'''Does nothing except decompresses the file'''
-		if "file_path" in self.env:
-			self.output("Using input .pack file %s to extract to %s" % (self.env["file_path"], self.env["destination"]))
-		self.env["results"] = self.unpack_the_file()
-		self.output("Unpacked: %s" % self.env["results"])
+    def main(self):
+        '''Does nothing except decompresses the file'''
+        if "file_path" in self.env:
+            self.output("Using input .pack file %s to extract to %s" % (self.env["file_path"], self.env["destination"]))
+        self.env["results"] = self.unpack_the_file()
+        self.output("Unpacked: %s" % self.env["results"])
 
 
 if __name__ == '__main__':
     processor = Unpack200()
     processor.execute_shell()
-    
-

--- a/Minecraft/Unpack200.py
+++ b/Minecraft/Unpack200.py
@@ -18,7 +18,9 @@
 # I will eventually fix it to make it much more robust, but it's more of a "get-it-done" kind of solution.
 
 from __future__ import absolute_import
+
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["Unpack200"]

--- a/MinecraftEdu/LastVersionProvider.py
+++ b/MinecraftEdu/LastVersionProvider.py
@@ -32,35 +32,34 @@ class LastVersionProvider(Processor):
             "description": "Version of the most recently packaged version. If none found, defaults to 0.0."
         }
     }
-    
+
     __doc__ = description
 
     def main(self):
         # Assign variables
-		receipts_path = os.path.join(self.env['RECIPE_CACHE_DIR'],'receipts')
-		if not os.path.isdir(receipts_path):
-			self.output("No receipts directory found.")
-			self.env['last_version'] = '0.0'
-			return
-		files = sorted([f for f in os.listdir(receipts_path)])
-		if not files:
-			self.output("No receipts found.")
-			self.env['last_version'] = '0.0'
-			return
-		path = os.path.join(self.env['RECIPE_CACHE_DIR'],'receipts',files[-1])
+        receipts_path = os.path.join(self.env['RECIPE_CACHE_DIR'], 'receipts')
+        if not os.path.isdir(receipts_path):
+            self.output("No receipts directory found.")
+            self.env['last_version'] = '0.0'
+            return
+        files = sorted([f for f in os.listdir(receipts_path)])
+        if not files:
+            self.output("No receipts found.")
+            self.env['last_version'] = '0.0'
+            return
+        path = os.path.join(self.env['RECIPE_CACHE_DIR'], 'receipts',files[-1])
 
-		# Try to read the plist
-		self.output("Reading: %s" % path)
-		try:
-			info = FoundationPlist.readPlist(path)
-		except (FoundationPlist.NSPropertyListSerializationException,
-				UnicodeEncodeError) as err:
-			raise ProcessorError(err)
-		self.env['last_version'] = info[1]['Output']['version']
-		self.output('Version found in receipts: %s' % self.env['version'])
+        # Try to read the plist
+        self.output("Reading: %s" % path)
+        try:
+            info = FoundationPlist.readPlist(path)
+        except (FoundationPlist.NSPropertyListSerializationException,
+                UnicodeEncodeError) as err:
+            raise ProcessorError(err)
+        self.env['last_version'] = info[1]['Output']['version']
+        self.output('Version found in receipts: %s' % self.env['version'])
         # end
 
 if __name__ == '__main__':
     processor = LastVersionProvider()
     processor.execute_shell()
-    

--- a/MinecraftEdu/LastVersionProvider.py
+++ b/MinecraftEdu/LastVersionProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import FoundationPlist
 

--- a/MinecraftEdu/LastVersionProvider.py
+++ b/MinecraftEdu/LastVersionProvider.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os
-import FoundationPlist
 
+import os
+
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["LastVersionProvider"]

--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 from distutils.version import LooseVersion
 from operator import itemgetter

--- a/MinecraftEdu/MinecraftEduURLProvider.py
+++ b/MinecraftEdu/MinecraftEduURLProvider.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
+import urllib2
 from distutils.version import LooseVersion
 from operator import itemgetter
-import urllib2
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["MinecraftEduURLProvider"]
 

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -16,13 +16,13 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import shutil
-
 from glob import glob
+
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
-
 
 __all__ = ["ParentCopier"]
 

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os.path
 import shutil
 
@@ -81,7 +82,7 @@ class ParentCopier(DmgMounter):
 					shutil.rmtree(dest_item)
 				else:
 					os.unlink(dest_item)
-			except OSError, err:
+			except OSError as err:
 				raise ProcessorError(
 					"Can't remove %s: %s" % (dest_item, err.strerror))
 					
@@ -94,7 +95,7 @@ class ParentCopier(DmgMounter):
 			else:
 				shutil.copy(source_item, dest_item)
 			self.output("Copied %s to %s" % (source_item, dest_item))
-		except BaseException, err:
+		except BaseException as err:
 			raise ProcessorError(
 				"Can't copy %s to %s: %s" % (source_item, dest_item, err))
 	

--- a/MinecraftEdu/ParentCopier.py
+++ b/MinecraftEdu/ParentCopier.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,117 +28,116 @@ __all__ = ["ParentCopier"]
 
 
 class ParentCopier(DmgMounter):
-	description = "Copies source_path to destination_path."
-	input_variables = {
-		"source_path": {
-			"required": True,
-			"description": ("Path to a file or directory to copy. "
-				"Can point to a path inside a .dmg which will be mounted. "
-				"This path may also contain basic globbing characters such as "
-				"the wildcard '*', but only the first result will be returned."),
-		},
-		"destination_path": {
-			"required": True,
-			"description": "Path to gdestination.",
-		},
-		"overwrite": {
-			"required": False,
-			"description": "Whether the destination will be overwritten if necessary.",
-		},
-	}
-	output_variables = {
-	}
-	
-	__doc__ = description
-	
-	def find_path_for_relpath(self, relpath):
-		'''Searches for the relative path.
-		Search order is:
-			RECIPE_CACHE_DIR
-			RECIPE_DIR
-			PARENT_RECIPE directories'''
-		cache_dir = self.env.get('RECIPE_CACHE_DIR')
-		recipe_dir = self.env.get('RECIPE_DIR')
-		search_dirs = [cache_dir, recipe_dir]
-		if self.env.get("PARENT_RECIPES"):
-			# also look in the directories containing the parent recipes
-			parent_recipe_dirs = list(set([
-				os.path.dirname(item)
-				for item in self.env["PARENT_RECIPES"]]))
-			search_dirs.extend(parent_recipe_dirs)
-		for directory in search_dirs:
-			test_item = os.path.join(directory, relpath)
-			if os.path.exists(test_item):
-				return os.path.normpath(test_item)
+    description = "Copies source_path to destination_path."
+    input_variables = {
+        "source_path": {
+            "required": True,
+            "description": ("Path to a file or directory to copy. "
+                "Can point to a path inside a .dmg which will be mounted. "
+                "This path may also contain basic globbing characters such as "
+                "the wildcard '*', but only the first result will be returned."),
+        },
+        "destination_path": {
+            "required": True,
+            "description": "Path to gdestination.",
+        },
+        "overwrite": {
+            "required": False,
+            "description": "Whether the destination will be overwritten if necessary.",
+        },
+    }
+    output_variables = {
+    }
 
-		raise ProcessorError("Can't find %s" % relpath)
+    __doc__ = description
 
-	def copy(self, source_item, dest_item, overwrite=False):
-		'''Copies source_item to dest_item, overwriting if allowed'''
-		# Remove destination if needed.
-		if os.path.exists(dest_item) and overwrite:
-			try:
-				if os.path.isdir(dest_item) and not os.path.islink(dest_item):
-					shutil.rmtree(dest_item)
-				else:
-					os.unlink(dest_item)
-			except OSError as err:
-				raise ProcessorError(
-					"Can't remove %s: %s" % (dest_item, err.strerror))
-					
-		# Copy file or directory.
-		try:
-			if os.path.isdir(source_item):
-				shutil.copytree(source_item, dest_item, symlinks=True)
-			elif not os.path.isdir(dest_item):
-				shutil.copyfile(source_item, dest_item)
-			else:
-				shutil.copy(source_item, dest_item)
-			self.output("Copied %s to %s" % (source_item, dest_item))
-		except BaseException as err:
-			raise ProcessorError(
-				"Can't copy %s to %s: %s" % (source_item, dest_item, err))
-	
-	def main(self):
-		source_path = self.env['source_path']
-		# Check if we're trying to copy something inside a dmg.
-		(dmg_path, dmg,
-		 dmg_source_path) = source_path.partition(".dmg/")
-		dmg_path += ".dmg"
+    def find_path_for_relpath(self, relpath):
+        '''Searches for the relative path.
+        Search order is:
+            RECIPE_CACHE_DIR
+            RECIPE_DIR
+            PARENT_RECIPE directories'''
+        cache_dir = self.env.get('RECIPE_CACHE_DIR')
+        recipe_dir = self.env.get('RECIPE_DIR')
+        search_dirs = [cache_dir, recipe_dir]
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the directories containing the parent recipes
+            parent_recipe_dirs = list(set([
+                os.path.dirname(item)
+                for item in self.env["PARENT_RECIPES"]]))
+            search_dirs.extend(parent_recipe_dirs)
+        for directory in search_dirs:
+            test_item = os.path.join(directory, relpath)
+            if os.path.exists(test_item):
+                return os.path.normpath(test_item)
 
-		# Check to see if it's a relative path and can be found inside the parent recipes
-		if source_path and not source_path.startswith("/"):
-			# search for it
-			source_path = self.find_path_for_relpath(source_path)
+        raise ProcessorError("Can't find %s" % relpath)
 
-		try:
-			if dmg:
-				# Mount dmg and copy path inside.
-				mount_point = self.mount(dmg_path)
-				source_path = os.path.join(mount_point, dmg_source_path)
-			# process path with glob.glob
-			matches = glob(source_path)
-			matched_source_path = matches[0]
-			if len(matches) > 1:
-				self.output("WARNING: Multiple paths match 'source_path' glob '%s':"
-					% source_path)
-				for match in matches:
-					self.output("  - %s" % match)
+    def copy(self, source_item, dest_item, overwrite=False):
+        '''Copies source_item to dest_item, overwriting if allowed'''
+        # Remove destination if needed.
+        if os.path.exists(dest_item) and overwrite:
+            try:
+                if os.path.isdir(dest_item) and not os.path.islink(dest_item):
+                    shutil.rmtree(dest_item)
+                else:
+                    os.unlink(dest_item)
+            except OSError as err:
+                raise ProcessorError(
+                    "Can't remove %s: %s" % (dest_item, err.strerror))
 
-			matched_source_path = glob(source_path)[0]
-			if [c for c in '*?[]!' if c in source_path]:
-				self.output("Using path '%s' matched from globbed '%s'."
-					% (matched_source_path, source_path))
+        # Copy file or directory.
+        try:
+            if os.path.isdir(source_item):
+                shutil.copytree(source_item, dest_item, symlinks=True)
+            elif not os.path.isdir(dest_item):
+                shutil.copyfile(source_item, dest_item)
+            else:
+                shutil.copy(source_item, dest_item)
+            self.output("Copied %s to %s" % (source_item, dest_item))
+        except BaseException as err:
+            raise ProcessorError(
+                "Can't copy %s to %s: %s" % (source_item, dest_item, err))
 
-			# do the copy
-			self.copy(matched_source_path, self.env['destination_path'],
-					  overwrite=self.env.get("overwrite"))
-		finally:
-			if dmg:
-				self.unmount(dmg_path)
-	
+    def main(self):
+        source_path = self.env['source_path']
+        # Check if we're trying to copy something inside a dmg.
+        (dmg_path, dmg,
+         dmg_source_path) = source_path.partition(".dmg/")
+        dmg_path += ".dmg"
+
+        # Check to see if it's a relative path and can be found inside the parent recipes
+        if source_path and not source_path.startswith("/"):
+            # search for it
+            source_path = self.find_path_for_relpath(source_path)
+
+        try:
+            if dmg:
+                # Mount dmg and copy path inside.
+                mount_point = self.mount(dmg_path)
+                source_path = os.path.join(mount_point, dmg_source_path)
+            # process path with glob.glob
+            matches = glob(source_path)
+            matched_source_path = matches[0]
+            if len(matches) > 1:
+                self.output("WARNING: Multiple paths match 'source_path' glob '%s':"
+                    % source_path)
+                for match in matches:
+                    self.output("  - %s" % match)
+
+            matched_source_path = glob(source_path)[0]
+            if [c for c in '*?[]!' if c in source_path]:
+                self.output("Using path '%s' matched from globbed '%s'."
+                    % (matched_source_path, source_path))
+
+            # do the copy
+            self.copy(matched_source_path, self.env['destination_path'],
+                      overwrite=self.env.get("overwrite"))
+        finally:
+            if dmg:
+                self.unmount(dmg_path)
+
 
 if __name__ == '__main__':
-	processor = ParentCopier()
-	processor.execute_shell()
-	
+    processor = ParentCopier()
+    processor.execute_shell()

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os
 import subprocess
 import shutil

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -110,7 +110,7 @@ class ParentUnarchiver(Processor):
             try:
                 os.mkdir(destination_path)
             except OSError as e:
-                raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
+                raise ProcessorError("Can't create %s: %s" % (destination_path, e.strerror))
         elif self.env.get('purge_destination'):
             for entry in os.listdir(destination_path):
                 path = os.path.join(destination_path, entry)

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -26,150 +26,149 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["ParentUnarchiver"]
 
 EXTNS = {
-	'zip': ['zip'],
-	'tar_gzip': ['tar.gz', 'tgz'],
-	'tar_bzip2': ['tar.bz2', 'tbz'],
-	'tar': ['tar']
+    'zip': ['zip'],
+    'tar_gzip': ['tar.gz', 'tgz'],
+    'tar_bzip2': ['tar.bz2', 'tbz'],
+    'tar': ['tar']
 }
 
 class ParentUnarchiver(Processor):
-	description = "Archive decompressor for zip and common tar-compressed formats. Also searches parent recipes if relative path is given."
-	input_variables = {
-		"archive_path": {
-			"required": False,
-			"description": "Path to an archive. Defaults to contents of the 'pathname' "
-						   "variable, for example as is set by URLDownloader.",
-		},
-		"destination_path": {
-			"required": False,
-			"description": ("Directory where archive will be unpacked, created if necessary. "
-						   "Defaults to RECIPE_CACHE_DIR/NAME.")
-		},
-		"purge_destination": {
-			"required": False,
-			"description": "Whether the contents of the destination directory will be removed before unpacking.",
-		},
-		"archive_format": {
-			"required": False,
-			"description": ("The archive format. Currently supported: 'zip', 'tar_gzip', 'tar_bzip2'. "
-						   "If omitted, the format will try to be guessed by the file extension.")
-		}
-	}
-	output_variables = {
-	}
-	
-	__doc__ = description
+    description = "Archive decompressor for zip and common tar-compressed formats. Also searches parent recipes if relative path is given."
+    input_variables = {
+        "archive_path": {
+            "required": False,
+            "description": "Path to an archive. Defaults to contents of the 'pathname' "
+                           "variable, for example as is set by URLDownloader.",
+        },
+        "destination_path": {
+            "required": False,
+            "description": ("Directory where archive will be unpacked, created if necessary. "
+                           "Defaults to RECIPE_CACHE_DIR/NAME.")
+        },
+        "purge_destination": {
+            "required": False,
+            "description": "Whether the contents of the destination directory will be removed before unpacking.",
+        },
+        "archive_format": {
+            "required": False,
+            "description": ("The archive format. Currently supported: 'zip', 'tar_gzip', 'tar_bzip2'. "
+                           "If omitted, the format will try to be guessed by the file extension.")
+        }
+    }
+    output_variables = {
+    }
 
-	def find_path_for_relpath(self, relpath):
-		'''Searches for the relative path.
-		Search order is:
-			RECIPE_CACHE_DIR
-			RECIPE_DIR
-			PARENT_RECIPE directories'''
-		cache_dir = self.env.get('RECIPE_CACHE_DIR')
-		recipe_dir = self.env.get('RECIPE_DIR')
-		search_dirs = [cache_dir, recipe_dir]
-		if self.env.get("PARENT_RECIPES"):
-			# also look in the directories containing the parent recipes
-			parent_recipe_dirs = list(set([
-				os.path.dirname(item)
-				for item in self.env["PARENT_RECIPES"]]))
-			search_dirs.extend(parent_recipe_dirs)
-		for directory in search_dirs:
-			test_item = os.path.join(directory, relpath)
-			if os.path.exists(test_item):
-				return os.path.normpath(test_item)
+    __doc__ = description
 
-		raise ProcessorError("Can't find %s" % relpath)
-			
-	def get_archive_format(self, archive_path):
-		for format, extns in EXTNS.items():
-			for extn in extns:
-				if archive_path.endswith(extn):
-					return format
-		# We found no known archive file extension if we got this far
-		return None
+    def find_path_for_relpath(self, relpath):
+        '''Searches for the relative path.
+        Search order is:
+            RECIPE_CACHE_DIR
+            RECIPE_DIR
+            PARENT_RECIPE directories'''
+        cache_dir = self.env.get('RECIPE_CACHE_DIR')
+        recipe_dir = self.env.get('RECIPE_DIR')
+        search_dirs = [cache_dir, recipe_dir]
+        if self.env.get("PARENT_RECIPES"):
+            # also look in the directories containing the parent recipes
+            parent_recipe_dirs = list(set([
+                os.path.dirname(item)
+                for item in self.env["PARENT_RECIPES"]]))
+            search_dirs.extend(parent_recipe_dirs)
+        for directory in search_dirs:
+            test_item = os.path.join(directory, relpath)
+            if os.path.exists(test_item):
+                return os.path.normpath(test_item)
 
-	def main(self):
-		# handle some defaults for archive_path and destination_path
-		archive_path = self.env.get("archive_path", self.env.get("pathname"))
-		if not archive_path:
-			raise ProcessorError("Expected an 'archive_path' input variable but none is set!")
-			
-		# convert relative path into absolute path by stealing code from PkgCreator
-		if archive_path and not archive_path.startswith("/"):
-					# search for it
-					archive_path = self.find_path_for_relpath(archive_path)
-		
-		
-		destination_path = self.env.get("destination_path",
-					os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+        raise ProcessorError("Can't find %s" % relpath)
 
-		# Create the directory if needed.
-		if not os.path.exists(destination_path):
-			try:
-				os.mkdir(destination_path)
-			except OSError as e:
-				raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
-		elif self.env.get('purge_destination'):
-			for entry in os.listdir(destination_path):
-				path = os.path.join(destination_path, entry)
-				try:
-					if os.path.isdir(path) and not os.path.islink(path):
-						shutil.rmtree(path)
-					else:
-						os.unlink(path)
-				except OSError as e:
-					raise ProcessorError("Can't remove %s: %s" % (path, e.strerror))
-		
-		fmt = self.env.get("archive_format")
-		if fmt is None:
-			fmt = self.get_archive_format(archive_path)
-			if not fmt:
-				raise ProcessorError("Can't guess archive format for filename %s" %
-						os.path.basename(archive_path))
-			self.output("Guessed archive format '%s' from filename %s" %
-						(fmt, os.path.basename(archive_path)))
-		elif fmt not in EXTNS.keys():
-			raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
-								(fmt, ", ".join(EXTNS.keys())))
+    def get_archive_format(self, archive_path):
+        for format, extns in EXTNS.items():
+            for extn in extns:
+                if archive_path.endswith(extn):
+                    return format
+        # We found no known archive file extension if we got this far
+        return None
 
-		if fmt == "zip":
-			cmd = ["/usr/bin/ditto",
-				   "--noqtn",
-				   "-x",
-				   "-k",
-				   archive_path,
-				   destination_path]
-		elif fmt.startswith("tar"):
-			cmd = ["/usr/bin/tar",
-				   "-x",
-				   "-f",
-				   archive_path,
-				   "-C",
-				   destination_path]
-			if fmt.endswith("gzip"):
-				cmd.append("-z")
-			elif fmt.endswith("bzip2"):
-				cmd.append("-j")
+    def main(self):
+        # handle some defaults for archive_path and destination_path
+        archive_path = self.env.get("archive_path", self.env.get("pathname"))
+        if not archive_path:
+            raise ProcessorError("Expected an 'archive_path' input variable but none is set!")
 
-		# Call command.
-		try:
-			p = subprocess.Popen(cmd,
-								 stdout=subprocess.PIPE,
-								 stderr=subprocess.PIPE)
-			(out, err) = p.communicate()
-		except OSError as e:
-			raise ProcessorError("%s execution failed with error code %d: %s" % (
-								  os.path.basename(cmd[0]), e.errno, e.strerror))
-		if p.returncode != 0:
-			raise ProcessorError("Unarchiving %s with %s failed: %s" % (
-								  archive_path, os.path.basename(cmd[0]), err))
-		
-		self.output("Unarchived %s to %s" 
-					% (archive_path, destination_path))
+        # convert relative path into absolute path by stealing code from PkgCreator
+        if archive_path and not archive_path.startswith("/"):
+                    # search for it
+                    archive_path = self.find_path_for_relpath(archive_path)
+
+
+        destination_path = self.env.get("destination_path",
+                    os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+
+        # Create the directory if needed.
+        if not os.path.exists(destination_path):
+            try:
+                os.mkdir(destination_path)
+            except OSError as e:
+                raise ProcessorError("Can't create %s: %s" % (path, e.strerror))
+        elif self.env.get('purge_destination'):
+            for entry in os.listdir(destination_path):
+                path = os.path.join(destination_path, entry)
+                try:
+                    if os.path.isdir(path) and not os.path.islink(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.unlink(path)
+                except OSError as e:
+                    raise ProcessorError("Can't remove %s: %s" % (path, e.strerror))
+
+        fmt = self.env.get("archive_format")
+        if fmt is None:
+            fmt = self.get_archive_format(archive_path)
+            if not fmt:
+                raise ProcessorError("Can't guess archive format for filename %s" %
+                        os.path.basename(archive_path))
+            self.output("Guessed archive format '%s' from filename %s" %
+                        (fmt, os.path.basename(archive_path)))
+        elif fmt not in EXTNS.keys():
+            raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
+                                (fmt, ", ".join(EXTNS.keys())))
+
+        if fmt == "zip":
+            cmd = ["/usr/bin/ditto",
+                   "--noqtn",
+                   "-x",
+                   "-k",
+                   archive_path,
+                   destination_path]
+        elif fmt.startswith("tar"):
+            cmd = ["/usr/bin/tar",
+                   "-x",
+                   "-f",
+                   archive_path,
+                   "-C",
+                   destination_path]
+            if fmt.endswith("gzip"):
+                cmd.append("-z")
+            elif fmt.endswith("bzip2"):
+                cmd.append("-j")
+
+        # Call command.
+        try:
+            p = subprocess.Popen(cmd,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+            (out, err) = p.communicate()
+        except OSError as e:
+            raise ProcessorError("%s execution failed with error code %d: %s" % (
+                                  os.path.basename(cmd[0]), e.errno, e.strerror))
+        if p.returncode != 0:
+            raise ProcessorError("Unarchiving %s with %s failed: %s" % (
+                                  archive_path, os.path.basename(cmd[0]), err))
+
+        self.output("Unarchived %s to %s"
+                    % (archive_path, destination_path))
 
 if __name__ == '__main__':
-	processor = ParentUnarchiver()
-	processor.execute_shell()
-	
+    processor = ParentUnarchiver()
+    processor.execute_shell()

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -16,12 +16,12 @@
 
 
 from __future__ import absolute_import
+
 import os
-import subprocess
 import shutil
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["ParentUnarchiver"]
 

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/MinecraftEdu/ParentUnarchiver.py
+++ b/MinecraftEdu/ParentUnarchiver.py
@@ -98,8 +98,8 @@ class ParentUnarchiver(Processor):
 
         # convert relative path into absolute path by stealing code from PkgCreator
         if archive_path and not archive_path.startswith("/"):
-                    # search for it
-                    archive_path = self.find_path_for_relpath(archive_path)
+            # search for it
+            archive_path = self.find_path_for_relpath(archive_path)
 
 
         destination_path = self.env.get("destination_path",
@@ -130,9 +130,9 @@ class ParentUnarchiver(Processor):
                         os.path.basename(archive_path))
             self.output("Guessed archive format '%s' from filename %s" %
                         (fmt, os.path.basename(archive_path)))
-        elif fmt not in EXTNS.keys():
+        elif fmt not in EXTNS:
             raise ProcessorError("'%s' is not valid for the 'archive_format' variable. Must be one of %s." %
-                                (fmt, ", ".join(EXTNS.keys())))
+                                (fmt, ", ".join(EXTNS)))
 
         if fmt == "zip":
             cmd = ["/usr/bin/ditto",

--- a/PostProcessors/Yo.py
+++ b/PostProcessors/Yo.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 import subprocess

--- a/PostProcessors/Yo.py
+++ b/PostProcessors/Yo.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
-import subprocess
 import os.path
+import subprocess
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["Yo"]
 
@@ -59,4 +60,3 @@ class Yo(Processor):
 if __name__ == "__main__":
     processor = Yo()
     processor.execute_shell()
-    


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including handling HTTP headers), but this should catch the low-hanging fruit right now.