### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/PostProcessors/Yo.py
+++ b/PostProcessors/Yo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2015 Nick McSpadden
 #
@@ -23,36 +23,37 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["Yo"]
 
+
 class Yo(Processor):
     description = "Provides a Yo notification if anything was imported."
     input_variables = {
         "munki_info": {
             "required": False,
-            "description": ("Munki info dictionary to use to display info.")
+            "description": ("Munki info dictionary to use to display info."),
         },
         "munki_repo_changed": {
             "required": False,
-            "description": ("Whether or not item was imported.")
+            "description": ("Whether or not item was imported."),
         },
         "yo_path": {
             "required": False,
-            "description": ("Path to yo.app. Defaults to /Applications "
-                            "/Utilities/yo.app.")
-        }
+            "description": (
+                "Path to yo.app. Defaults to /Applications " "/Utilities/yo.app."
+            ),
+        },
     }
-    output_variables = {
-    }
-    
+    output_variables = {}
+
     __doc__ = description
-   
+
     def main(self):
         was_imported = self.env.get("munki_repo_changed")
         munkiInfo = self.env.get("munki_info")
         yo_path = self.env.get("yo_path") or "/Applications/Utilities/yo.app"
-        yo = os.path.join(yo_path, 'Contents/MacOS/yo')
+        yo = os.path.join(yo_path, "Contents/MacOS/yo")
         if was_imported:
             subtext = "%s was imported" % munkiInfo["name"]
-            cmd = [yo, "-t", "Autopkg", "-s", subtext ]
+            cmd = [yo, "-t", "Autopkg", "-s", subtext]
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (cmd_out, cmd_err) = proc.communicate()
 


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.