### PR TITLE
fixing chefclient and chefdk parentrecipe string

### DIFF
--- a/ChefClient/Chef.munki.recipe
+++ b/ChefClient/Chef.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.download.ChefClient</string>
+    <string>com.github.nmcspadden.download.ChefClient</string>
     <key>Process</key>
     <array>
         <dict>

--- a/ChefDK/ChefDK.munki.recipe
+++ b/ChefDK/ChefDK.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.download.chefdk</string>
+    <string>com.github.nmcspadden.download.chefdk</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
was getting 
```
autopkg info Chef.munki
Didn't find a recipe for  com.github.download.chefclient
autopkg info ChefDK.munki
Didn't find a recipe for  com.github.download.chefdk
```
this fixed my autopkg munki recipe runs