### PR TITLE
Exclude Release Candidates as well

### DIFF
--- a/Xcode/README.md
+++ b/Xcode/README.md
@@ -137,7 +137,7 @@ clear the `BETA` tag:
 		<key>BETA</key>
 		<string></string>
 		<key>PATTERN</key>
-		<string>((?!.*beta).*\/Xcode_.*\/Xcode.*.xip)</string>
+		<string>((?!.*beta)(?!.*Candidate).*\/Xcode_.*\/Xcode.*.xip)</string>
 ```
 
 **Override for latest Xcode of any type**


### PR DESCRIPTION
This update does a better job of generating a non-beta version by excluding releases with the term `Candidate` in them, such as _Xcode 14.1 Release Candidate 2_.