### PR TITLE
Update the Identifier to be unique

### DIFF
--- a/PostProcessors/SharedPostProcessors.recipe
+++ b/PostProcessors/SharedPostProcessors.recipe
@@ -6,7 +6,7 @@
     <string>Recipe stub for any Shared Processors in this directory.
     </string>
     <key>Identifier</key>
-    <string>com.github.nmcspadden.shared</string>
+    <string>com.github.nmcspadden.shared.postprocessors</string>
     <key>Input</key>
     <dict/>
     <key>MinimumVersion</key>


### PR DESCRIPTION
In #47, it was suggested to delete this stub recipe, however, if that is done, then the `Yo.py` Post Processor would not be usable.

I bet, considering `nmcspadden-recipes/PostProcessors/SharedProcessors.recipe` was created six years ago, you just forgot about it when you moved your recipes/shared processors from the Facebook repo into this one and simply renamed the identifier in `nmcspadden-recipes/Shared_Processors/SharedProcessors.recipe` to match normal conventions (again, forgetting you had used it six years ago).  An honest mistake I'm sure.

So, the options are:
* Set a unique identifier in _*at least one*_ of the stub recipes in:
  * `nmcspadden-recipes/PostProcessors/SharedProcessors.recipe` or
  * `nmcspadden-recipes/Shared_Processors/SharedProcessors.recipe`
* Combine the two directories and and rename one of the README files
* (Other options are there, but likely involve more work and complications for users of your recipes)

Considering it doesn't look like anyone is yelling that they can't use the `Yo.py` Post Processor, I took the approach to effect the least amount of people with this change.