### PR TITLE
Make it more obvious how to use the two methods for passing developer accounts' password

### DIFF
--- a/Xcode/AppleDataGatherer.py
+++ b/Xcode/AppleDataGatherer.py
@@ -67,18 +67,18 @@ class AppleDataGatherer(Processor):
 
     def main(self):
         """Store the login data file."""
-        appleIDstring = f'appleId={quote(self.env["apple_id"])}&'
-        appIDKeystring = f"appIdKey={self.env['appID_key']}&"
-        if not self.env.get("password") and not self.env.get("password_file"):
-            raise ProcessorError(
-                "You must provide either a password, or a password_file argument."
-            )
-        password = self.env.get("password")
-        if self.env.get("password_file"):
+        if self.env.get("password") not in [None, "%PASSWORD%"]:
+            password = self.env.get("password")
+        elif self.env.get("password_file") not in [None, "%PASSWORD_FILE%"]:
             with open(self.env["password_file"]) as f:
                 password = f.read()
+        if not password:
+            raise ProcessorError(
+                "You must provide either the 'password' or 'password_file' argument."
+            )
+        appleIDstring = f"appleId={quote(self.env['apple_id'])}&"
+        appIDKeystring = f"appIdKey={self.env['appID_key']}&"
         passwordstring = f"accountPassword={password}"
-
         login_data = appleIDstring + appIDKeystring + passwordstring
         download_dir = os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads")
         filename = "login_data"

--- a/Xcode/Xcode.download.recipe
+++ b/Xcode/Xcode.download.recipe
@@ -17,6 +17,8 @@
             <string>secret.txt</string>
             <key>NOSKIP</key>
             <string></string>
+            <key>PASSWORD</key>
+            <string></string>
             <key>BETA</key>
             <string></string>
             <key>PATTERN</key>
@@ -39,6 +41,8 @@
                     <string>%APPLE_ID%</string>
                     <key>password_file</key>
                     <string>%PASSWORD_FILE%</string>
+                    <key>password</key>
+                    <string>%PASSWORD%</string>
                     <key>appID_key</key>
                     <string>891bd3417a7776362562d2197f89480a8547b108fd934911bcbea0110d07f757</string>
                 </dict>

--- a/Xcode/Xcode.download.recipe
+++ b/Xcode/Xcode.download.recipe
@@ -4,7 +4,7 @@
     <!-- Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved -->
     <dict>
         <key>Description</key>
-        <string>Download Xcode from the Apple dev portal. You must override the APPLE_ID and PASSWORD_FILE. BETA must either be empty for stable releases or set to "Beta" in order to match Xcode betas.</string>
+        <string>Download Xcode from the Apple dev portal. You must override the APPLE_ID and one of PASSWORD or PASSWORD_FILE. BETA must either be empty for stable releases or set to "Beta" in order to match Xcode betas.</string>
         <key>Identifier</key>
         <string>com.github.nmcspadden.download.xcode</string>
         <key>Input</key>

--- a/Xcode/Xcode.munki.recipe
+++ b/Xcode/Xcode.munki.recipe
@@ -4,7 +4,7 @@
     <!-- Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved -->
     <dict>
         <key>Description</key>
-        <string>Download, extract, and import Xcode into Munki. You must override the APPLE_ID and PASSWORD.</string>
+        <string>Download, extract, and import Xcode into Munki. You must override the APPLE_ID and one of PASSWORD or PASSWORD_FILE.</string>
         <key>Identifier</key>
         <string>com.github.nmcspadden.munki.xcode</string>
         <key>Input</key>

--- a/Xcode/XcodeVersionedName.munki.recipe
+++ b/Xcode/XcodeVersionedName.munki.recipe
@@ -5,7 +5,7 @@
         <key>Copyright</key>
         <string>Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved</string>
         <key>Description</key>
-        <string>Download, extract, and import Xcode as a unique entry into Munki. You must override the APPLE_ID and PASSWORD.</string>
+        <string>Download, extract, and import Xcode as a unique entry into Munki. You must override the APPLE_ID and one of PASSWORD or PASSWORD_FILE.</string>
         <key>Identifier</key>
         <string>com.github.nmcspadden.munki.xcode_versioned</string>
         <key>Input</key>
@@ -20,8 +20,6 @@
             <string>apps/apple/xcode/</string>
             <key>NAME</key>
             <string>Xcode</string>
-            <key>PASSWORD_FILE</key>
-            <string>secret.txt</string>
             <!-- Arbitrary_suffix optionally adds string between Xcode_X.Y.Z and .app -->
             <key>ARBITRARY_SUFFIX</key>
             <string></string>


### PR DESCRIPTION
This change simply makes it more obvious how to use the two different methods to pass the developer accounts' password.

+ Simplified the password conditional logic in `AppleDataGatherer`
+ Added an overridable `PASSWORD` Input variable to the `AppleDataGatherer` Processor step in `Xcode.download.recipe`
+ Updated recipes description to clarify supported methods for passing the developer accounts' password

This is an improved PR from [#58](https://github.com/facebookarchive/Recipes-for-AutoPkg/pull/58) that I submitted and retracted in the old Facebook repo.