### PR TITLE
Move beta/RC version identification logic to prevent Python crash

### DIFF
--- a/Xcode/AppleDataGatherer.py
+++ b/Xcode/AppleDataGatherer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -23,14 +23,9 @@
 
 import os
 
+from urllib.parse import quote
+
 from autopkglib import Processor, ProcessorError
-
-
-try:
-    # python 2
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
 
 
 __all__ = ["AppleDataGatherer"]
@@ -42,30 +37,38 @@ class AppleDataGatherer(Processor):
     description = __doc__
     input_variables = {
         "apple_id": {
-            "required": True,
-            "description": ("AppleID that can log into the Apple dev portal."),
+            "description": "AppleID that can log into the Apple dev portal.",
+            "required": True
         },
         "password": {
-            "required": False,
-            "description": ("Password for AppleID that can log into Apple dev portal."),
+            "description": (
+                "Password for AppleID that can log into Apple dev portal."
+            ),
+            "required": False
         },
         "password_file": {
-            "required": False,
             "description": (
-                "A path to a file to read the password from. Using this will "
-                "ignore the 'password' argument."
+                "A path to a file to read the password from. Using "
+                "this will ignore the 'password' argument."
             ),
+            "required": False
         },
-        "appID_key": {"required": True, "description": ("App ID key to log into.")},
+        "appID_key": {
+            "description": "App ID key to log into.",
+            "required": True
+        }
     }
-    output_variables = {"data_pathname": {"description": "Path to the data file."}}
+    output_variables = {
+        "data_pathname": {
+            "description": "Path to the data file."
+        }
+    }
 
-    __doc__ = description
 
     def main(self):
         """Store the login data file."""
-        appleIDstring = "appleId={}&".format(quote(self.env["apple_id"]))
-        appIDKeystring = "appIdKey={}&".format(self.env["appID_key"])
+        appleIDstring = f'appleId={quote(self.env["apple_id"])}&'
+        appIDKeystring = f"appIdKey={self.env['appID_key']}&"
         if not self.env.get("password") and not self.env.get("password_file"):
             raise ProcessorError(
                 "You must provide either a password, or a password_file argument."
@@ -74,7 +77,7 @@ class AppleDataGatherer(Processor):
         if self.env.get("password_file"):
             with open(self.env["password_file"]) as f:
                 password = f.read()
-        passwordstring = "accountPassword={}".format(password)
+        passwordstring = f"accountPassword={password}"
 
         login_data = appleIDstring + appIDKeystring + passwordstring
         download_dir = os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads")
@@ -85,7 +88,7 @@ class AppleDataGatherer(Processor):
                 os.makedirs(download_dir)
             except OSError as err:
                 raise ProcessorError(
-                    "Can't create %s: %s" % (download_dir, err.strerror)
+                    f"Can't create {download_dir}: {err.strerror}"
                 )
         self.output("Writing data to file")
         self.env["data_pathname"] = os.path.join(download_dir, filename)

--- a/Xcode/XcodeBuildNumberEmitter.py
+++ b/Xcode/XcodeBuildNumberEmitter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -30,24 +30,27 @@ class XcodeBuildNumberEmitter(Processor):
     description = __doc__
     input_variables = {
         "dont_skip": {
-            "required": False,
+            "description": (
+                "If this evaluates as truthy, do not skip this step."
+            ),
             "default": False,
-            "description": ("If this evaluates as truthy, do not skip this step."),
+            "required": False
         },
         "build_version": {
-            "required": True,
-            "description": ("The build version number for this Xcode Release"),
+            "description": "The build version number for this Xcode Release",
+            "required": True
         },
         "output_filepath": {
-            "required": True,
-            "description": ("Path to which xcode build number is emitted."),
-        },
+            "description": "Path to which xcode build number is emitted.",
+            "required": True
+        }
     }
     output_variables = {
-        "derived_filename": {"description": "The derived filename to emit."}
+        "derived_filename": {
+            "description": "The derived filename to emit."
+        }
     }
 
-    __doc__ = description
 
     def main(self):
         """Main."""
@@ -56,16 +59,13 @@ class XcodeBuildNumberEmitter(Processor):
             return
 
         build_number = self.env["build_version"]
-
         destination = os.path.expandvars(self.env["output_filepath"])
+
         with open(destination, "w") as f:
             f.write(build_number)
-            self.output(
-                "Xcode build number ({}) written to disk at {}".format(
-                    build_number,
-                    destination,
-                )
-            )
+        self.output(
+            f"Xcode build number ({build_number}) written to disk at {destination}"
+        )
 
 
 if __name__ == "__main__":

--- a/Xcode/XcodeFileNamer.py
+++ b/Xcode/XcodeFileNamer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -32,15 +32,15 @@ class XcodeFileNamer(Processor):
                 "Whether or not we should produce a versioned name. "
                 "If this is non-empty, it's evaluated as true."
             ),
-            "required": True,
+            "required": True
         },
         "major_version": {
             "description": "Major version of Xcode - i.e. Xcode 7, 8.",
-            "required": True,
+            "required": True
         },
         "minor_version": {
             "description": "Minor version of Xcode - i.e. Xcode X.1, X.2.",
-            "required": True,
+            "required": True
         },
         "patch_version": {
             "description": (
@@ -48,62 +48,61 @@ class XcodeFileNamer(Processor):
                 "Patch version will be normalized to 0 if missing (i.e. 8.3 "
                 "becomes 8.3.0)."
             ),
-            "required": True,
+            "required": True
         },
         "is_beta": {
-            "description": ("Boolean that is true if this Xcode is a beta version."),
-            "required": True,
+            "description": (
+                "Boolean that is true if this Xcode is a beta version."
+            ),
+            "required": True
         },
         "beta_version": {
             "description": (
                 "The beta number - 1, 2, 3, etc. Only used if is_beta is True. "
                 "Assumed to be 0 if not provided."
             ),
-            "required": False,
+            "required": False
         },
         "should_lowercase": {
             "description": (
-                "If this value is non-empty, use a lower-case filename - xcode_X.Y.0_suffix.app."
+                "If this value is non-empty, use a lower-case "
+                "filename - xcode_X.Y.0_suffix.app."
             ),
-            "required": False,
+            "required": False
         },
         "suffix": {
             "description": (
-                "Any additional suffix string to append to the name prior to the .app extension."
+                "Any additional suffix string to append to "
+                "the name prior to the .app extension."
             ),
-            "required": False,
-        },
+            "required": False
+        }
     }
     output_variables = {
-        "xcode_filename": {"description": "Allow producing a versioned Xcode name."}
+        "xcode_filename": {
+            "description": "Allow producing a versioned Xcode name."
+        }
     }
 
-    __doc__ = description
 
     def main(self):
         """Main."""
-        if not self.env["should_produce_versioned_name"] and self.env["is_beta"]:
-            # Default name for Xcode Beta
-            self.env["xcode_filename"] = "Xcode-beta"
-            return
-        elif not self.env["should_produce_versioned_name"]:
-            # Default name for Xcode
-            self.env["xcode_filename"] = "Xcode"
+        if not self.env["should_produce_versioned_name"]:
+            # Set the default name for Xcode Beta or the default name for Xcode
+            self.env["xcode_filename"] = "Xcode-beta" if self.env["is_beta"] else "Xcode"
             return
         # end up with xcode_10.2.0_beta_4 or xcode_10.2.1
-        prefix = "Xcode"
-        if self.env.get("should_lowercase"):
-            prefix = "xcode"
+        prefix = "xcode" if self.env.get("should_lowercase") else "Xcode"
         name = "{}_{}.{}.{}".format(
             prefix,
             self.env["major_version"],
             self.env["minor_version"],
-            self.env["patch_version"],
+            self.env["patch_version"]
         )
         if self.env["is_beta"]:
-            name = name + "_beta_{}".format(self.env.get("beta_version", "0"))
+            name += f"_beta_{self.env.get('beta_version', '0')}"
         name += self.env.get("suffix", "")
-        self.output("Xcode name: {}".format(name))
+        self.output(f"Xcode name: {name}")
         self.env["xcode_filename"] = name
 
 

--- a/Xcode/XcodeVersionEmitter.py
+++ b/Xcode/XcodeVersionEmitter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -16,16 +16,11 @@
 #
 """Get all Version information from Xcode."""
 
-import os.path
+from os.path import basename, expandvars, splitext
+
+from urllib.parse import urlsplit
 
 from autopkglib import Processor
-
-
-try:
-    # python 2
-    from urlparse import urlsplit
-except ImportError:
-    from urllib.parse import urlsplit
 
 
 __all__ = ["XcodeVersionEmitter"]
@@ -37,21 +32,27 @@ class XcodeVersionEmitter(Processor):
     description = __doc__
     input_variables = {
         "dont_skip": {
-            "required": False,
+            "description": (
+                "If this evaluates as truthy, do not skip this step."
+            ),
             "default": False,
-            "description": ("If this evaluates as truthy, do not skip this step."),
+            "required": False
         },
-        "url": {"required": True, "description": ("URL to parse the version from.")},
+        "url": {
+            "description": "URL to parse the version from.",
+            "required": True
+        },
         "output_filepath": {
-            "required": True,
-            "description": ("Path to which xcode version tag is emitted."),
-        },
+            "description": "Path to which xcode version tag is emitted.",
+            "required": True
+        }
     }
     output_variables = {
-        "derived_filename": {"description": "The derived filename to emit."}
+        "derived_filename": {
+            "description": "The derived filename to emit."
+        }
     }
 
-    __doc__ = description
 
     def main(self):
         """Main."""
@@ -62,18 +63,15 @@ class XcodeVersionEmitter(Processor):
         url_split_object = urlsplit(url)
         # "https://download.developer.apple.com/Developer_Tools/Xcode_10.2.1/Xcode_10.2.1.xip"  # noqa
         # "https://developer.apple.com//services-account/download?path=/Developer_Tools/Xcode_11_Beta_2/Xcode_11_Beta_2.xip"  # noqa
-        filename = os.path.splitext(os.path.basename(url_split_object.path))[0].lower()
-        self.output("Derived filename: {}".format(filename))
+        filename = splitext(basename(url_split_object.path))[0].lower()
+        self.output(f"Derived filename: {filename}")
         self.env["derived_filename"] = filename
 
-        destination = os.path.expandvars(self.env["output_filepath"])
+        destination = expandvars(self.env["output_filepath"])
         with open(destination, "w") as f:
             f.write(filename)
-            self.output(
-                "Derived filename ({}) written to disk at {}".format(
-                    filename, destination
-                )
-            )
+        self.output(
+            f"Derived filename ({filename}) written to disk at {destination}")
 
 
 if __name__ == "__main__":

--- a/Xcode/XcodeVersioner.py
+++ b/Xcode/XcodeVersioner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -16,16 +16,15 @@
 #
 """Get all Version information from Xcode."""
 
-
 from collections import namedtuple
-
-from autopkglib import Processor, ProcessorError
-
 
 try:
     import objc
 except ImportError:
     pass
+
+from autopkglib import Processor, ProcessorError
+
 
 __all__ = ["XcodeVersioner"]
 
@@ -36,21 +35,24 @@ class XcodeVersioner(Processor):
     description = __doc__
     input_variables = {
         "version": {
-            "required": True,
             "description": (
-                "CFBundleShortVersionString from an Xcode Info.plist. Produced by "
-                "PlistReader."
+                "CFBundleShortVersionString from an Xcode Info.plist. "
+                "Produced by PlistReader."
             ),
+            "required": True,
         },
         "app_path": {
-            "required": True,
             "description": (
-                "Path to Xcode app to look up version information from the bundle."
+                "Path to Xcode app to look up version"
+                "information from the bundle."
             ),
-        },
+            "required": True
+        }
     }
     output_variables = {
-        "major_version": {"description": "Major version of Xcode - i.e. Xcode 7, 8."},
+        "major_version": {
+            "description": "Major version of Xcode - i.e. Xcode 7, 8."
+        },
         "minor_version": {
             "description": "Minor version of Xcode - i.e. Xcode X.1, X.2."
         },
@@ -62,29 +64,30 @@ class XcodeVersioner(Processor):
             )
         },
         "is_beta": {
-            "description": ("Boolean that is true if this Xcode is a beta version.")
+            "description": (
+                "Boolean that is true if this Xcode is a beta version."
+            )
         },
-        "beta_version": {"description": ("The beta number - 1, 2, 3, etc.")},
-        "build_version": {"description": ("Build version of Xcode - e.g. 11B500")},
+        "beta_version": {
+            "description": "The beta number - 1, 2, 3, etc."
+        },
+        "build_version": {
+            "description": "Build version of Xcode - e.g. 11B500"
+        }
     }
 
-    __doc__ = description
 
     def _load_objc_framework(self, f_name, f_path, class_whitelist):
         loaded = {}
         framework_bundle = objc.loadBundle(  # NOQA
             f_name, bundle_path=f_path, module_globals=loaded
         )
-        desired = {}
-        for x in class_whitelist:
-            if x in loaded:
-                desired[x] = loaded[x]
+        desired = {x: loaded[x] for x in class_whitelist if x in loaded}
         return namedtuple("AttributedFramework", desired.keys())(**desired)
 
+
     def xcode_info(self, app_path):
-        DVTFoundation_path = (
-            "%s/Contents/SharedFrameworks/" + "DVTFoundation.framework"
-        ) % app_path
+        DVTFoundation_path = f"{app_path}/Contents/SharedFrameworks/DVTFoundation.framework"
         desired_classes = ["DVTToolsInfo"]
         DVTFoundation = self._load_objc_framework(
             "DVTFoundation", DVTFoundation_path, desired_classes
@@ -92,18 +95,20 @@ class XcodeVersioner(Processor):
         x_info = DVTFoundation.DVTToolsInfo.toolsInfo()
         x_v = x_info.toolsVersion()
         x_b = x_info.toolsBuildVersion()
-        app_info = []
-        app_info.append(["major_version", str(x_v.versionMajorComponent())])
-        app_info.append(["minor_version", str(x_v.versionMinorComponent())])
-        app_info.append(["patch_version", str(x_v.versionUpdateComponent())])
-        app_info.append(["build_version", x_b.name()])
         is_beta = bool(x_info.isBeta())
-        app_info.append(["is_beta", is_beta])
+        app_info = [
+            ["major_version", str(x_v.versionMajorComponent())],
+            ["minor_version", str(x_v.versionMinorComponent())],
+            ["patch_version", str(x_v.versionUpdateComponent())],
+            ["build_version", x_b.name()],
+            ["is_beta", is_beta]
+        ]
         if is_beta:
             app_info.append(["beta_version", str(x_info.toolsBetaVersion())])
         else:
             app_info.append(["beta_version", "0"])
         return app_info
+
 
     def main(self):
         """Main."""
@@ -115,27 +120,26 @@ class XcodeVersioner(Processor):
                 "literally everything again."
             )
         self.env["major_version"] = str(split_string[0])
-        self.output("Major version: %s" % self.env["major_version"])
+        self.output(f"Major version: {self.env['major_version']}")
         self.env["minor_version"] = str(split_string[1])
-        self.output("Minor version: %s" % self.env["minor_version"])
+        self.output(f"Minor version: {self.env['minor_version']}")
         try:
             self.env["patch_version"] = split_string[2]
         except IndexError:
             self.output("Normalizing patch to 0")
-            self.env["patch_version"] = str("0")
+            self.env["patch_version"] = "0"
         self.env["is_beta"] = False
         xcode_info_results = self.xcode_info(self.env["app_path"])
-        xcode_data = {}
-        for info_pair in xcode_info_results:
-            xcode_data[info_pair[0]] = info_pair[1]
+        xcode_data = {
+            info_pair[0]: info_pair[1] for info_pair in xcode_info_results
+        }
         if xcode_data["is_beta"]:
-            self.output("Beta version: %s" % xcode_data["beta_version"])
+            self.output(f"Beta version: {xcode_data['beta_version']}")
             self.env["is_beta"] = xcode_data["is_beta"]
             self.env["beta_version"] = xcode_data["beta_version"]
-        self.output("Patch version: %s" % self.env["patch_version"])
-
+        self.output(f"Patch version: {self.env['patch_version']}")
         self.env["build_version"] = xcode_data["build_version"]
-        self.output("Build version: %s" % self.env["build_version"])
+        self.output(f"Build version: {self.env['build_version']}")
 
 
 if __name__ == "__main__":

--- a/Xcode/XcodeXIPUnpacker.py
+++ b/Xcode/XcodeXIPUnpacker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
@@ -28,20 +28,22 @@ __all__ = ["XcodeXIPUnpacker"]
 class XcodeXIPUnpacker(Processor):
     """Unpack a XIP file from Apple."""
 
-    description = "Unpack an Apple XIP file."
+    description = __doc__
     input_variables = {
-        "PKG": {"required": True, "description": "Path to an Xcode .xip file."},
+        "PKG": {
+            "description": "Path to an Xcode .xip file.",
+            "required": True
+        },
         "output_path": {
-            "required": False,
             "description": (
                 "Path to unpack the contents. Defaults to "
                 "%RECIPE_CACHE_DIR%/%NAME%_unpack."
             ),
-        },
+            "required": False
+        }
     }
     output_variables = {}
 
-    __doc__ = description
 
     def main(self):
         """Main."""
@@ -60,7 +62,9 @@ class XcodeXIPUnpacker(Processor):
         )
         os.chdir(output)
         cmd = ["/usr/bin/xip", "--expand", xip_path]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         (out, err) = proc.communicate()
         if err:
             raise ProcessorError(err)
@@ -68,5 +72,5 @@ class XcodeXIPUnpacker(Processor):
 
 
 if __name__ == "__main__":
-    processor = XcodeXIPUnpacker()
-    processor.execute_shell()
+    PROCESSOR = XcodeXIPUnpacker()
+    PROCESSOR.execute_shell()


### PR DESCRIPTION
Move beta/RC version identification logic to prevent Python crash

Full credit to @vdesouza in [PR #61](https://github.com/facebookarchive/Recipes-for-AutoPkg/pull/61) which was submitted to fix [Issue #59](https://github.com/facebookarchive/Recipes-for-AutoPkg/issues/59) in the old Facebook repo.

This is a _slightly_ modified revision of that code.