### PR TITLE
Removing duplicate Processor

### DIFF
--- a/Xcode/Xcode.download.recipe
+++ b/Xcode/Xcode.download.recipe
@@ -67,15 +67,6 @@
             </dict>
             <dict>
                 <key>Processor</key>
-                <string>AppleCookieDownloader</string>
-                <key>Arguments</key>
-                <dict>
-                    <key>login_data</key>
-                    <string>%RECIPE_CACHE_DIR%/downloads/login_data</string>
-                </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
                 <string>XcodeVersionEmitter</string>
                 <key>Arguments</key>
                 <dict>


### PR DESCRIPTION
The `AppleCookieDownloader` Processor is listed twice in the Xcode `download` recipe.

I can't determine any reason why this was listed twice and it works just fine with it removed for me.