### PR TITLE
Subclass URLGetter, Use JSON Download List

### DIFF
--- a/Xcode/AppleCookieDownloader.py
+++ b/Xcode/AppleCookieDownloader.py
@@ -18,16 +18,14 @@
 
 import json
 import os.path
-import subprocess
-import time
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import ProcessorError, URLGetter
 
 
 __all__ = ["AppleCookieDownloader"]
 
 
-class AppleCookieDownloader(Processor):
+class AppleCookieDownloader(URLGetter):
     """Downloads a URL to the specified download_dir using curl."""
 
     description = __doc__
@@ -35,11 +33,6 @@ class AppleCookieDownloader(Processor):
         "login_data": {
             "description": "Path to login data file.",
             "required": True
-        },
-        "CURL_PATH": {
-            "description": "Path to curl binary. Defaults to /usr/bin/curl.",
-            "default": "/usr/bin/curl",
-            "required": False
         }
     }
     output_variables = {
@@ -47,113 +40,6 @@ class AppleCookieDownloader(Processor):
             "description": "Path to the download cookies."
         }
     }
-
-
-    def download(
-        self, url, curl_opts, output, request_headers, allow_failure=False
-    ):
-        """Run a download with curl."""
-        # construct curl command.
-        curl_cmd = [
-            self.env["CURL_PATH"],
-            "--silent",
-            "--show-error",
-            "--no-buffer",
-            "--fail",
-            "--dump-header",
-            "-",
-            "--speed-time",
-            "30",
-            "--location",
-            "--url",
-            url,
-            "--output",
-            output
-        ]
-
-        if request_headers:
-            for header, value in request_headers.items():
-                curl_cmd.extend(["--header", f"{header}: {value}"])
-
-        if curl_opts:
-            for item in curl_opts:
-                curl_cmd.extend([item])
-
-        # Open URL.
-        proc = subprocess.Popen(
-            curl_cmd,
-            shell=False,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-
-        donewithheaders = False
-        maxheaders = 15
-        header = {
-            "http_result_code": "000",
-            "http_result_description": ""
-        }
-
-        while True:
-            if not donewithheaders:
-                info = proc.stdout.readline().decode().strip("\r\n")
-                if info.startswith("HTTP/"):
-                    try:
-                        header["http_result_code"] = info.split(None, 2)[1]
-                        header["http_result_description"] = info.split(
-                            None, 2)[2]
-                    except IndexError:
-                        pass
-                elif ": " in info:
-                    # got a header line
-                    part = info.split(None, 1)
-                    fieldname = part[0].rstrip(":").lower()
-                    try:
-                        header[fieldname] = part[1]
-                    except IndexError:
-                        header[fieldname] = ""
-                elif info == "":
-                    # we got an empty line; end of headers (or curl exited)
-                    if header.get("http_result_code") in [
-                        "301",
-                        "302",
-                        "303",
-                        "307",
-                        "308"
-                    ]:
-                        # redirect, so more headers are coming.
-                        # Throw away the headers we've received so far
-                        header = {}
-                        header["http_result_code"] = "000"
-                        header["http_result_description"] = ""
-                    else:
-                        donewithheaders = True
-            else:
-                time.sleep(0.1)
-
-            if proc.poll() is not None:
-                # For small download files curl may exit before all headers
-                # have been parsed, don't immediately exit.
-                maxheaders -= 1
-                if donewithheaders or maxheaders <= 0:
-                    break
-
-        retcode = proc.poll()
-        if (
-            retcode and not allow_failure
-        ):  # Non-zero exit code from curl => problem with download
-            curlerr = ""
-            try:
-                curlerr = proc.stderr.read().rstrip("\n")
-                curlerr = curlerr.split(None, 2)[2]
-            except IndexError:
-                pass
-
-            raise ProcessorError(
-                f"Curl failure: {curlerr} (exit code {retcode})"
-            )
 
 
     def main(self):
@@ -168,83 +54,69 @@ class AppleCookieDownloader(Processor):
                 raise ProcessorError(
                     f"Can't create {download_dir}: {err.strerror}"
                 )
-
-        self.output("Getting login cookie")
         # We need to POST a request to the auth page to get the
         # 'myacinfo' cookie
-        login_curl_opts = [
+        self.output("Getting login cookie")
+        # Base curl options
+        base_curl_opts = [
             "--request",
             "POST",
+            "--silent",
+            "--show-error",
+            "--no-buffer",
+            "--dump-header", "-",
+            "--speed-time", "30"
+        ]
+        # Curl options to acquire login cookies
+        login_curl_opts = [
+            "--url",
+            "https://idmsa.apple.com/IDMSWebAuth/authenticate",
             "--data",
             f"@{self.env['login_data']}",
             "--cookie-jar",
-            login_cookies
-        ]
-        self.download(
-            url="https://idmsa.apple.com/IDMSWebAuth/authenticate",
-            curl_opts=login_curl_opts,
-            output="-",
-            request_headers=None,
-            allow_failure=True
-        )
-        self.output("Getting download cookie")
-        # Now we need to get the download cookie
-        dl_curl_opts = [
-            "--request",
-            "POST",
-            "--cookie",
             login_cookies,
-            "--cookie-jar",
-            download_cookies
+            "--output",
+            "-"
         ]
-        headers = {"Content-length": "0"}
-        output = os.path.join(download_dir, "listDownloads.gz")
+        # Initialize the curl_cmd, add base curl options, and execute curl
+        prepped_curl_cmd = self.prepare_curl_cmd()
+        self.download_with_curl(
+            prepped_curl_cmd + base_curl_opts + login_curl_opts
+        )
+        # Now we need to get the download cookie
+        output = os.path.join(download_dir, "listDownloads.json")
+        self.output("Getting download cookie")
         if os.path.exists(output):
             # Delete it first
             os.unlink(output)
-        self.download(
-            url="https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action",
-            curl_opts=dl_curl_opts,
-            output=output,
-            request_headers=headers,
-            allow_failure=True
+        # Curl options to acquire the download list
+        dl_curl_opts = [
+            "--url",
+            "https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action",
+            "--cookie",
+            login_cookies,
+            "--cookie-jar",
+            download_cookies,
+            "--output",
+            output
+        ]
+        headers = {"Content-length": "0"}
+        self.add_curl_headers(dl_curl_opts, headers)
+        self.download_with_curl(
+            prepped_curl_cmd + base_curl_opts + dl_curl_opts
         )
         self.env["download_cookies"] = download_cookies
         try:
             with open(output) as f:
+                # Verify this can be successfully loaded this as JSON
                 json.load(f)
-                # If we successfully load this as JSON, then we failed
-                # to download the gzip list
-                raise ProcessorError(
-                    "Unable to list downloads. Check your Apple credentials."
-                )
-        except IOError:
-            raise ProcessorError("Unable to load listDownloads.gz file.")
-        except ValueError:
-            pass
-        # While we're at it, let's unzip the download list
-        # It's actually a gunzip, so Unarchiver doesn't work
-        # The result is a JSON blob
-        self.output("Unzipping download list")
-        os.chdir(download_dir)
-        if os.path.exists(output.rstrip(".gz")):
-            # Delete the file if it's already here
-            os.unlink(output.rstrip(".gz"))
-        gunzip_cmd = ["/usr/bin/gunzip", output]
-        proc = subprocess.Popen(
-            gunzip_cmd,
-            shell=False,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        (stdout, stderr) = proc.communicate()
-        if proc.returncode:
-            gzerr = stderr.rstrip("\n")
+        except IOError as error:
             raise ProcessorError(
-                f"Gunzip failure: {gzerr} (exit code {proc.returncode})"
-            )
+                "Unable to load the listDownloads.json file.") from error
+        except Exception as error:
+            raise ProcessorError(
+                f"Unknown error loading the list of downloads. Error:  {error}") from error
+        self.output("Successfully acquired the download list")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
+ Subclass `URLGetter` and utilize it's methods instead of building `curl` commands and shelling out within the Processor
+ Utilize the JSON download list instead of attempting to obtain and use a `.gz` gunzip version

I'm not sure if there is a reason why you did the things the way they were, so feel free to let me know if there is something I'm missing, but with these changes, everything still works fine for me.*

*The only thing that isn't working for me is downloading Beta versions of Xcode.  I can use the `--key "BETA=True"` input variable and it'll look for Beta versions (using the URL identified in #56), but only the latest stable version is ever matched.  I can't say I tested/used prior to things breaking in the old Facebook repo to know how it worked though.

If it's broken due to changes from Apple's side, then I have an idea to refactor the `AppleURLSearcher` Processor to allow an override to specify a release type to be downloaded.  I'm happy to submit a PR if you want.