### PR TITLE
Update GoogleEarthPro.munki.recipe

### DIFF
--- a/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe
+++ b/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads latest Google Earth Pro disk image and imports into Munki.</string>
+    <string>Downloads latest Google Earth Pro disk image and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.nmcspadden-recipes.munki.google-earth-pro</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>NAME</key>
         <string>GoogleEarthPro</string>
         <key>MUNKI_REPO_SUBDIR</key>
@@ -29,7 +33,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.nmcspadden-recipes.download.google-earth-pro</string>
     <key>Process</key>
@@ -111,6 +115,8 @@
                 </array>
                 <key>version_comparison_key</key>
                 <string>CFBundleVersion</string>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @nmcspadden 

The GoogleEarthPro Munki recipe currently doesn't set the `min_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.6.0

This change requires AutoPkg version 2.7 or a higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/nmcspadden-recipes/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/nmcspadden-recipes/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/nmcspadden-recipes/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 13 Dec 2022 05:51:49 GMT
URLDownloader: Storing new ETag header: "10c3dde"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/downloads/GoogleEarthPro.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/downloads/GoogleEarthPro.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.wNXBbJ/Install Google Earth Pro 7.3.6.9326.pkg' matched from globbed '/private/tmp/dmg.wNXBbJ/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Google Earth Pro 7.3.6.9326.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-13 05:30:08 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Google LLC (EQHXZ8M8AV)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            40 02 6A 12 12 38 F4 E0 3F 7B CE 86 FA 5A 22 2B DA 7A 3A 20 70 FF 
CodeSignatureVerifier:            28 0D 86 AA 4E 02 56 C5 B2 B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack/root
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack/root/Applications
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack/root/Library
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/downloads/GoogleEarthPro.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.kIhmbI/Install Google Earth Pro 7.3.6.9326.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/expanded
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/expanded/Google_Earth_Pro.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack/root/Applications
Versioner
Versioner: Found version 7.3.6.9326 in file /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack/root/Applications/Google Earth Pro.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '7.3.6.9326'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Google Earth Pro.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.6.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '7.3.6.9326', 'installs': [{'CFBundleIdentifier': 'com.Google.GoogleEarthPro', 'CFBundleName': 'Google Earth Pro', 'CFBundleShortVersionString': '7.3', 'CFBundleVersion': '7.3.6.9326', 'minosversion': '10.6.0', 'path': '/Applications/Google Earth Pro.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}], 'minimum_os_version': '10.6.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/GoogleEarthPro-7.3.6.9326.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/GoogleEarthPro-7.3.6.9326.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/expanded
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/receipts/GoogleEarthPro.munki-receipt-20221220-152518.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    /Users/paul/Library/AutoPkg/Cache/com.github.nmcspadden-recipes.munki.google-earth-pro/downloads/GoogleEarthPro.dmg  

The following new items were imported into Munki:
    Name            Version     Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----            -------     --------  ------------                          -------------                       --------------  
    GoogleEarthPro  7.3.6.9326  testing   apps/GoogleEarthPro-7.3.6.9326.plist  apps/GoogleEarthPro-7.3.6.9326.dmg 
```
