### PR TITLE
Fix DbVisualizer recipes and add ARCH input variable

### DIFF
--- a/DbVisualizer/DbVisualizer.dmg.recipe
+++ b/DbVisualizer/DbVisualizer.dmg.recipe
@@ -14,11 +14,20 @@
 			<string>DbVisualizer</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>0.5.0</string>
+		<string>1.1</string>
 		<key>ParentRecipe</key>
 		<string>com.github.nmcspadden.download.dbvisualizer</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>DbVisualizer already provides a dmg download, so this recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>

--- a/DbVisualizer/DbVisualizer.download.recipe
+++ b/DbVisualizer/DbVisualizer.download.recipe
@@ -5,7 +5,14 @@
 		<key>Copyright</key>
 		<string>Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved</string>
 		<key>Description</key>
-		<string>Downloads the latest version of DbVisualizer.</string>
+		<string>Downloads the latest version of DbVisualizer.
+		
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "aarch64" (Apple Silicon)
+
+Tested with VERSION values: 24.2, 24.1, 23.2, 23.1, and 14.0
+</string>
 		<key>Identifier</key>
 		<string>com.github.nmcspadden.download.dbvisualizer</string>
 		<key>Input</key>
@@ -13,7 +20,9 @@
 			<key>NAME</key>
 			<string>DbVisualizer</string>
 			<key>VERSION</key>
-			<string>11</string>
+			<string>24.2</string>
+			<key>ARCH</key>
+			<string>x64</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>0.5.0</string>
@@ -23,9 +32,20 @@
 				<key>Arguments</key>
 				<dict>
 					<key>re_pattern</key>
-					<string>\/.*.tgz(?=")</string>
+					<string>href="(https://www\.dbvis\.com/download/%VERSION%/)"</string>
 					<key>url</key>
-					<string>https://www.dbvis.com/download/%VERSION%.0</string>
+					<string>https://www.dbvis.com/version-list/</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLTextSearcher</string>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>re_pattern</key>
+					<string>href="/(product_download/dbvis-[\d\.]+/media/dbvis_macos-%ARCH%_[\d_]+\.dmg)"</string>
+					<key>url</key>
+					<string>%match%</string>
 				</dict>
 				<key>Processor</key>
 				<string>URLTextSearcher</string>
@@ -34,7 +54,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>url</key>
-					<string>https:%match%</string>
+					<string>https://www.dbvis.com/%match%</string>
 				</dict>
 				<key>Processor</key>
 				<string>URLDownloader</string>

--- a/DbVisualizer/DbVisualizer.munki.recipe
+++ b/DbVisualizer/DbVisualizer.munki.recipe
@@ -41,26 +41,14 @@
 		<key>MinimumVersion</key>
 		<string>0.5.0</string>
 		<key>ParentRecipe</key>
-		<string>com.github.nmcspadden.dmg.dbvisualizer</string>
+		<string>com.github.nmcspadden.download.dbvisualizer</string>
 		<key>Process</key>
 		<array>
 			<dict>
 				<key>Arguments</key>
 				<dict>
-					<key>additional_pkginfo</key>
-					<dict>
-						<key>version</key>
-						<string>%version%</string>
-					</dict>
-				</dict>
-				<key>Processor</key>
-				<string>MunkiPkginfoMerger</string>
-			</dict>
-			<dict>
-				<key>Arguments</key>
-				<dict>
 					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+					<string>%pathname%</string>
 					<key>repo_subdirectory</key>
 					<string>%MUNKI_REPO_SUBDIR%</string>
 				</dict>

--- a/DbVisualizer/DbVisualizer.pkg.recipe
+++ b/DbVisualizer/DbVisualizer.pkg.recipe
@@ -20,73 +20,8 @@
 		<key>Process</key>
 		<array>
 			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>pkgdirs</key>
-					<dict>
-						<key>Applications</key>
-						<string>0775</string>
-					</dict>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				</dict>
 				<key>Processor</key>
-				<string>PkgRootCreator</string>
-			</dict>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>archive_path</key>
-					<string>%pathname%</string>
-					<key>destination_path</key>
-					<string>%pkgroot%/Applications</string>
-					<key>purge_destination</key>
-					<true/>
-				</dict>
-				<key>Processor</key>
-				<string>Unarchiver</string>
-			</dict>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>input_plist_path</key>
-					<string>%pkgroot%/Applications/DbVisualizer.app/Contents/Info.plist</string>
-					<key>plist_version_key</key>
-					<string>CFBundleShortVersionString</string>
-				</dict>
-				<key>Comment</key>
-				<string>Get version from the app</string>
-				<key>Processor</key>
-				<string>Versioner</string>
-			</dict>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>pkg_request</key>
-					<dict>
-						<key>chown</key>
-						<array>
-							<dict>
-								<key>group</key>
-								<string>admin</string>
-								<key>path</key>
-								<string>Applications</string>
-								<key>user</key>
-								<string>root</string>
-							</dict>
-						</array>
-						<key>id</key>
-						<string>com.dbvis.DbVisualizer</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
-						<key>pkgname</key>
-						<string>%NAME%-%version%</string>
-						<key>version</key>
-						<string>%version%</string>
-					</dict>
-				</dict>
-				<key>Processor</key>
-				<string>PkgCreator</string>
+				<string>AppPkgCreator</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
This PR updates the download page and patterns used to download DbVisualizer. An ARCH variable has been added to specify whether to download Intel or Apple Silicon architecture builds, and the VERSION variable has been updated to 24.2 default. I also tested the VERSION back to 14.0 successfully.
