### PR TITLE
Fix Android NDK recipes

### DIFF
--- a/android_ndk/android_ndk.download.recipe
+++ b/android_ndk/android_ndk.download.recipe
@@ -23,9 +23,9 @@
 				<key>Arguments</key>
 				<dict>
 					<key>re_pattern</key>
-					<string>"(https:\/\/dl\.google\.com\/android\/repository\/android-ndk-%RELEASE%-darwin-x86_64.zip)"</string>
+					<string>"(https://dl\.google\.com/android/repository/android-ndk-%RELEASE%-darwin\.dmg)"</string>
 					<key>url</key>
-					<string>https://github.com/android-ndk/ndk/wiki</string>
+					<string>https://github.com/android/ndk/wiki</string>
 				</dict>
 				<key>Processor</key>
 				<string>URLTextSearcher</string>


### PR DESCRIPTION
This PR adjusts the file pattern used to download Android NDK releases.

Verbose recipe run output:

```
% autopkg run -vvq 'android_ndk/android_ndk.download.recipe'
Processing android_ndk/android_ndk.download.recipe...
WARNING: android_ndk/android_ndk.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"(https://dl\\.google\\.com/android/repository/android-ndk-r.*-darwin\\.dmg)"',
           'url': 'https://github.com/android/ndk/wiki'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://dl.google.com/android/repository/android-ndk-r27c-darwin.dmg
{'Output': {'match': 'https://dl.google.com/android/repository/android-ndk-r27c-darwin.dmg'}}
URLDownloader
{'Input': {'url': 'https://dl.google.com/android/repository/android-ndk-r27c-darwin.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 16 Oct 2024 20:31:56 GMT
URLDownloader: Storing new ETag header: "347ce14"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.nmcspadden.download.android_ndk/downloads/android-ndk-r27c-darwin.dmg
{'Output': {'download_changed': True,
            'etag': '"347ce14"',
            'last_modified': 'Wed, 16 Oct 2024 20:31:56 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.nmcspadden.download.android_ndk/downloads/android-ndk-r27c-darwin.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.nmcspadden.download.android_ndk/downloads/android-ndk-r27c-darwin.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.nmcspadden.download.android_ndk/receipts/android_ndk.download-receipt-20241227-123425.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.nmcspadden.download.android_ndk/downloads/android-ndk-r27c-darwin.dmg
```

