### PR TITLE
Deprecate Google Earth recipes

### DIFF
--- a/LegacyRecipes/CreateUserPkgMunki/createuserpkg.munki.recipe
+++ b/LegacyRecipes/CreateUserPkgMunki/createuserpkg.munki.recipe
@@ -30,15 +30,15 @@
 	</dict>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Processor</key>
-            <string>DeprecationWarning</string>
-            <key>Arguments</key>
-            <dict>
-                <key>warning_message</key>
-                <string>This recipe is no longer supported. Please remove it from your recipe list.</string>
-            </dict>
-        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is no longer supported. Please remove it from your recipe list.</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/LegacyRecipes/DragonDictate3/DragonDictate3.download.recipe
+++ b/LegacyRecipes/DragonDictate3/DragonDictate3.download.recipe
@@ -12,7 +12,7 @@
         <string>DragonDictate3</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.download.recipe
+++ b/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.download.recipe
@@ -14,9 +14,18 @@
         <string>https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is no longer supported. Please remove it from your recipe list.</string>
+			</dict>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe
+++ b/LegacyRecipes/GoogleEarthPro/GoogleEarthPro.munki.recipe
@@ -35,7 +35,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
     <key>MinimumVersion</key>
     <string>2.7</string>
     <key>ParentRecipe</key>
-    <string>com.github.nmcspadden-recipes.download.google-earth-pro</string>
+    <string>com.github.nstrauss.download.GoogleEarthPro</string>
     <key>Process</key>
     <array>
         <!-- Make a fake pkg root -->


### PR DESCRIPTION
This PR deprecates the Google Earth recipes in the LegacyRecipes folder.